### PR TITLE
Fix path resolve on Windows. Fixes #3

### DIFF
--- a/src/rules/no-relative.ts
+++ b/src/rules/no-relative.ts
@@ -3,6 +3,7 @@ import { dirname, resolve, basename } from "node:path";
 import nanomatch from "nanomatch";
 import { docsUrl } from "../utils/docs-url";
 import { resolveAliases } from "../utils/resolve-aliases";
+import slash from "../utils/slash";
 
 export const noRelative = {
   meta: {
@@ -55,13 +56,12 @@ export const noRelative = {
           return;
         }
 
-        const resolved = resolve(dirname(filePath), importPath);
-        const excepted = matchExceptions(resolved, exceptions);
+        const resolved = slash(resolve(dirname(filePath), importPath));
 
+        const excepted = matchExceptions(resolved, exceptions);
         if (excepted) return;
 
         const alias = matchToAlias(resolved, aliases);
-
         if (!alias) return;
 
         context.report({
@@ -84,11 +84,12 @@ export const noRelative = {
           return;
         }
 
-        const resolved = resolve(dirname(filePath), importPath);
-        const excepted = matchExceptions(resolved, exceptions);
-        const alias = matchToAlias(resolved, aliases);
+        const resolved = slash(resolve(dirname(filePath), importPath));
 
+        const excepted = matchExceptions(resolved, exceptions);
         if (excepted) return;
+
+        const alias = matchToAlias(resolved, aliases);
         if (!alias) return;
 
         context.report({

--- a/src/utils/resolve-aliases.ts
+++ b/src/utils/resolve-aliases.ts
@@ -3,6 +3,7 @@ import { type TsConfigResult, getTsconfig } from "get-tsconfig";
 import { resolve, dirname } from "node:path";
 import findPkg from "find-pkg";
 import { readFileSync } from "node:fs";
+import slash from "./slash";
 
 export function resolveAliases(
   context: Rule.RuleContext
@@ -37,7 +38,7 @@ function resolvePackageImports(pkg: any, pkgPath: string) {
   Object.entries(imports).forEach(([alias, path]) => {
     if (!path) return;
     if (typeof path !== "string") return;
-    const resolved = resolve(base, path);
+    const resolved = slash(resolve(base, path));
     aliases.set(alias, [resolved]);
   });
 
@@ -50,12 +51,12 @@ function resolveTsconfigPaths(config: TsConfigResult) {
   let base = dirname(config.path);
 
   if (config.config.compilerOptions?.baseUrl) {
-    base = resolve(dirname(config.path), config.config.compilerOptions.baseUrl);
+    base = slash(resolve(dirname(config.path), config.config.compilerOptions.baseUrl));
   }
 
   Object.entries(paths).forEach(([alias, path]) => {
     alias = alias.replace(/\/\*$/, "");
-    path = path.map((p) => resolve(base, p.replace(/\/\*$/, "")));
+    path = path.map((p) => slash(resolve(base, p.replace(/\/\*$/, ""))));
     aliases.set(alias, path);
   });
 
@@ -76,7 +77,7 @@ function resolveCustomPaths(context: Rule.RuleContext) {
     }
 
     const cwd = context.getCwd?.() ?? context.cwd;
-    const resolved = resolve(cwd, path);
+    const resolved = slash(resolve(cwd, path));
     aliases.set(alias, [resolved]);
   });
 

--- a/src/utils/slash.ts
+++ b/src/utils/slash.ts
@@ -1,0 +1,9 @@
+export default function slash(path) {
+	const isExtendedLengthPath = path.startsWith('\\\\?\\');
+
+	if (isExtendedLengthPath) {
+		return path;
+	}
+
+	return path.replace(/\\/g, '/');
+}


### PR DESCRIPTION
Fix path resolve on Windows. 

Fixes #3

All tests are ✅ after this fix on Windows (before fix was 16 passing + 16 failing).

I didn't want to add another dependency, so I copied the `slash.ts` contents from https://github.com/sindresorhus/slash.